### PR TITLE
Use envelope instead of mean to detect IES

### DIFF
--- a/neurokit/analysis/suppressions.py
+++ b/neurokit/analysis/suppressions.py
@@ -50,11 +50,13 @@ def detect_ies(recording: Recording,
     if not channels:
         channels = recording.channels
     rec = _eliminate_artifacts(recording)
-    avg = rec.data.loc[:, channels].values.mean(axis=1)
+    envelope = recording.data.loc[:, channels].abs().values.max(axis=1)
     min_length = math.ceil(min_duration * rec.frequency)
+
     with np.errstate(invalid='ignore'):
-        ies_mask = np.abs(avg) < threshold
+        ies_mask = envelope < threshold
     ies_mask = binary_opening(ies_mask, np.ones(min_length))
+
     intervals = mask_to_intervals(ies_mask, rec.data.index)
     detections = [{'start': start,
                    'end': end,


### PR DESCRIPTION
Use the envelope, defined as the max in absolute value across the channels, to detect iso-electric suppressions. This assumes that suppressions are global events, i.e. signal in all electrodes must have small amplitude.

Fixes #33 